### PR TITLE
update debian from 10 to 11

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 
-FROM debian:buster-slim
+FROM debian:bullseye-slim
 
 ARG BRANCH=release
 


### PR DESCRIPTION
Currently we have error `./altv-voice-server: /usr/lib/x86_64-linux-gnu/libstdc++.so.6: version GLIBCXX_3.4.26 not found (required by ./altv-voice-server)`
Altv says that we need at least Debian 11 to use all those stuff